### PR TITLE
Update CLI args pattern

### DIFF
--- a/resolvers/dotnet/Tools/dtdl2-validator/ModelValidationService.cs
+++ b/resolvers/dotnet/Tools/dtdl2-validator/ModelValidationService.cs
@@ -52,7 +52,7 @@ namespace dtdl2_validator
                 Environment.ExitCode = 1;
                 log.LogError(ex, "DTDL Parser Exception");
             }
-
+            await Task.Delay(500);
         }
 
         private void ConfigureResolver(ModelParser parser, string resolverName)
@@ -99,12 +99,12 @@ namespace dtdl2_validator
 
         (string, string) ReadConfiguration(IConfiguration config)
         {
-            string input = config.GetValue<string>("f");
+            string input = config.GetValue<string>("file");
             string resolver = config.GetValue<string>("resolver"); ;
 
             if (string.IsNullOrEmpty(input))
             {
-                Console.WriteLine("Usage: dtdl2-validator /f=<dtdlFile.json> /resolver?=<public|local|none>");
+                Console.WriteLine("Usage: dtdl2-validator -f <dtdlFile.json> -r <public|local|none>");
                 Environment.ExitCode = 2;
             }
             else

--- a/resolvers/dotnet/Tools/dtdl2-validator/Program.cs
+++ b/resolvers/dotnet/Tools/dtdl2-validator/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace dtdl2_validator
@@ -10,10 +11,20 @@ namespace dtdl2_validator
         {
             var cancellationTokenSource = new CancellationTokenSource(5000);
 
+            var cliArgs = new Dictionary<string, string>()
+            {
+                {"-f", "file" },
+                {"--file", "file" },
+                {"-r", "resolver" },
+                {"--resolver", "resolver" },
+                {"-bf", "baseFolder" },
+                {"--baseFolder", "baseFolder" }
+            };
+
             IConfiguration config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                 .AddEnvironmentVariables()
-                .AddCommandLine(args)
+                .AddCommandLine(args, cliArgs)
                 .Build();
             
             ILogger logger = LoggerFactory.Create(builder =>

--- a/resolvers/dotnet/Tools/dtdl2-validator/Properties/launchSettings.json
+++ b/resolvers/dotnet/Tools/dtdl2-validator/Properties/launchSettings.json
@@ -2,19 +2,19 @@
   "profiles": {
     "default-resolver": {
       "commandName": "Project",
-      "commandLineArgs": "/f=../../../test/demodevice.json"
+      "commandLineArgs": "-f ../../../test/demodevice.json"
     },
     "none-resolver": {
       "commandName": "Project",
-      "commandLineArgs": "/f=../../../test/demodevice.json /resolver=none"
+      "commandLineArgs": "-f ../../../test/demodevice.json -r none"
     },
     "public-resolver": {
       "commandName": "Project",
-      "commandLineArgs": "/f=../../../test/demodevice.json /resolver=public /Logging:LogLevel:Default=Trace"
+      "commandLineArgs": "-f ../../../test/demodevice.json --resolver public /Logging:LogLevel:Default=Trace"
     },
     "local-resolver": {
       "commandName": "Project",
-      "commandLineArgs": "/f=../../../test/demodevice.json /resolver=local /baseFolder=C:\\TestModelRegistry\\ /Logging:LogLevel:Default=Trace"
+      "commandLineArgs": "-f ../../../test/demodevice.json -r local --baseFolder C:/code/device-models-tools/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry /Logging:LogLevel:Default=Trace"
     }
   }
 }


### PR DESCRIPTION
Configure the CLI configuration to allow

```
-f <fileName> -r <Resolver>
--file <fileName> --resolver <Resolver>
```

> /fileName=<fileName> is still valid to allow other configuration sources such as EnvVars or config.json files