### PR TITLE
Introduces the resolver client CLI with MVP functionality.

### DIFF
--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Microsoft</Copyright>
+    <Company>Microsoft</Company>
+    <Authors>Microsoft</Authors>
+    <Version>0.0.1</Version>
+    <AssemblyName>resolverclient</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20371.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.DigitalTwins.Resolver.Extensions\Azure.DigitalTwins.Resolver.Extensions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Program.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Program.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.Azure.DigitalTwins.Parser;
+using Azure.DigitalTwins.Resolver.Extensions;
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Hosting;
+using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+
+namespace Azure.DigitalTwins.Resolver.CLI
+{
+    class Program
+    {
+        private static readonly string _defaultRegistry = "https://devicemodeltest.azureedge.net/";
+        private static readonly string _parserVersion = typeof(ModelParser).Assembly.GetName().Version.ToString();
+
+        static async Task<int> Main(string[] args) => await BuildCommandLine()
+            .UseHost(_ => Host.CreateDefaultBuilder())
+            .UseDefaults()
+            .Build()
+            .InvokeAsync(args);
+
+        private static CommandLineBuilder BuildCommandLine()
+        {
+            RootCommand root = new RootCommand("parent")
+            {
+                Description = "Microsoft IoT Plug and Play Model Resolution CLI"
+            };
+
+            root.Add(BuildShowCommand());
+            root.Add(BuildValidateCommand());
+
+            return new CommandLineBuilder(root);
+        }
+
+
+        private static ResolverClient InitializeClient(string registry)
+        {
+            ResolverClient client;
+            client = Directory.Exists(registry) ?
+                ResolverClient.FromLocalRegistry(registry) : ResolverClient.FromRemoteRegistry(registry);
+            return client;
+        }
+
+        private static Command BuildShowCommand()
+        {
+            Command showModel = new Command("show")
+            {
+                new Option<string>(
+                    "--dtmi",
+                    description: "Digital Twin Model Identifier. Example: dtmi:com:example:Thermostat;1"){
+                    Argument = new Argument<string>
+                    {
+                        Arity = ArgumentArity.ExactlyOne,
+                    },
+                    IsRequired = true
+                },
+                new Option<string>(
+                    "--registry",
+                    description: "Model Registry location. Can be remote endpoint or local directory.",
+                    getDefaultValue: () => _defaultRegistry
+                    ),
+            };
+
+            showModel.Description = "Retrieve a model and its dependencies by dtmi using the target registry for model resolution.";
+            showModel.Handler = CommandHandler.Create<string, string, IHost>(async (dtmi, registry, host) =>
+            {
+                IServiceProvider serviceProvider = host.Services;
+                ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+                ILogger logger = loggerFactory.CreateLogger(typeof(Program));
+
+                IDictionary<string, string> result;
+                try
+                {
+                    logger.LogInformation($"Using registry location {registry}");
+                    result = await InitializeClient(registry).ResolveAsync(dtmi);
+                }
+                catch(DirectoryNotFoundException dnfex)
+                {
+                    logger.LogError(dnfex.Message);
+                    return 1; // TODO: define error codes
+                }
+                catch (FileNotFoundException fnfex)
+                {
+                    logger.LogError(fnfex.Message);
+                    return 1;
+                }
+                catch (HttpRequestException httpex)
+                {
+                    logger.LogError(httpex.Message);
+                    return 1;
+                }
+
+                List<string> resultList = result.Values.ToList();
+                string normalizedList = string.Join(',', resultList);
+                await Console.Out.WriteLineAsync("[" + string.Join(',', normalizedList) + "]");
+
+                return 0;
+            });
+
+            return showModel;
+        }
+
+        private static Command BuildValidateCommand()
+        {
+            Command validateModel = new Command("validate")
+            {
+                new Option<FileInfo>(
+                    "--model-file",
+                    description: "Path to file containing Digital Twins model content."){
+                    Argument = new Argument<FileInfo>().ExistingOnly(),
+                    IsRequired = true
+                },
+                new Option<string>(
+                    "--registry",
+                    description: "Model Registry location. Can be remote endpoint or local directory.",
+                    getDefaultValue: () => _defaultRegistry
+                    ),
+            };
+
+            validateModel.Description = "Validates a model using the Digital Twins parser and target registry for model resolution.";
+            validateModel.Handler = CommandHandler.Create<FileInfo, string, IHost>(async (modelFile, registry, host) =>
+            {
+                // TODO: DRY
+                IServiceProvider serviceProvider = host.Services;
+                ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+                ILogger logger = loggerFactory.CreateLogger(typeof(Program));
+
+                ResolverClient client = InitializeClient(registry);
+
+                logger.LogInformation($"Parser version: {_parserVersion}");
+                ModelParser parser = new ModelParser
+                {
+                    Options = new HashSet<ModelParsingOption>() { ModelParsingOption.StrictPartitionEnforcement }
+                };
+
+                parser.DtmiResolver = client.ParserDtmiResolver;
+
+                try
+                {
+                    logger.LogInformation($"Registry location: {registry}");
+                    await parser.ParseAsync(new string[] { File.ReadAllText(modelFile.FullName) });
+                }
+                catch (ResolutionException resolutionEx)
+                {
+                    logger.LogError(resolutionEx.Message);
+                    return 1; // TODO define error codes.
+                }
+                catch (ParsingException parsingEx)
+                {
+                    IList<ParsingError> errors = parsingEx.Errors;
+                    string normalizedErrors = string.Empty;
+                    foreach(ParsingError error in errors)
+                    {
+                        normalizedErrors += $"{error.Message}{Environment.NewLine}";
+                    }
+
+                    logger.LogError(normalizedErrors);
+
+                    return 2;
+                }
+
+                return 0;
+            });
+
+            return validateModel;
+        }
+    }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Properties/launchSettings.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowBasic": {
+      "commandName": "Project",
+      "commandLineArgs": "show --dtmi dtmi:com:example:Thermostat;1"
+    },
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ValidateBasic": {
+      "commandName": "Project",
+      "commandLineArgs": "validate --model-file ../../../../Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/thermostat-1.json"
+    },
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ValidateFail": {
+      "commandName": "Project",
+      "commandLineArgs": "validate --model-file ../../../../Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/invalidmodel-2.json"
+    }
+  }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/appsettings.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Trace",
+      "Microsoft": "Warning"
+    }
+  }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ClientInitTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ClientInitTests.cs
@@ -29,13 +29,13 @@ namespace Azure.DigitalTwins.Resolver.Tests
             string registryPathWindows = @"C:\Users\me\path\to\registy";
             string registryPathLinux = "/me/path/to/registry";
 
-            Uri registryUriWindows = new Uri($@"file://{registryPathWindows}");
+            Uri registryUriWindows = new Uri($"file://{registryPathWindows}");
             var clientWindows = ResolverClient.FromLocalRegistry(registryPathWindows);
 
             Assert.AreEqual(registryUriWindows, clientWindows.RegistryUri);
             Assert.AreEqual(registryPathWindows.Replace('\\', '/'), clientWindows.RegistryUri.AbsolutePath);
 
-            Uri registryUriLinux = new Uri($@"file://{registryPathLinux}");
+            Uri registryUriLinux = new Uri($"file://{registryPathLinux}");
             var clientLinux = ResolverClient.FromLocalRegistry(registryPathLinux);
 
             Assert.AreEqual(registryUriLinux, clientLinux.RegistryUri);

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/DtmiConversionTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/DtmiConversionTests.cs
@@ -12,13 +12,13 @@ namespace Azure.DigitalTwins.Resolver.Tests
             string dtmiVariation2 = "dtmi:com:example:Model;1";
 
             string registryBasePathWindows = @"C:\fakeRegistry\";
-            string expectedPathWindows = $@"{registryBasePathWindows}/dtmi/com/example/model-1.json";
+            string expectedPathWindows = $"{registryBasePathWindows}/dtmi/com/example/model-1.json";
 
             Assert.AreEqual(expectedPathWindows, DtmiConventions.ToPath(dtmiVariation1, registryBasePathWindows));
             Assert.AreEqual(expectedPathWindows, DtmiConventions.ToPath(dtmiVariation2, registryBasePathWindows));
 
             string registryBasePathLinux = "/me/fakeRegistry";
-            string expectedPathLinux = $@"{registryBasePathLinux}/dtmi/com/example/model-1.json";
+            string expectedPathLinux = $"{registryBasePathLinux}/dtmi/com/example/model-1.json";
 
             Assert.AreEqual(expectedPathLinux, DtmiConventions.ToPath(dtmiVariation1, registryBasePathLinux));
             Assert.AreEqual(expectedPathLinux, DtmiConventions.ToPath(dtmiVariation2, registryBasePathLinux));
@@ -31,7 +31,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
             string dtmiVariation2 = "dtmi:com:example:Model;1";
 
             string registryBaseEndpoint = "http://localhost/registry";
-            string expectedPath = $@"{registryBaseEndpoint}/dtmi/com/example/model-1.json";
+            string expectedPath = $"{registryBaseEndpoint}/dtmi/com/example/model-1.json";
 
             Assert.AreEqual(expectedPath, DtmiConventions.ToPath(dtmiVariation1, registryBaseEndpoint));
             Assert.AreEqual(expectedPath, DtmiConventions.ToPath(dtmiVariation2, registryBaseEndpoint));

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/FetchIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/FetchIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
     public class FetchIntegrationTests
     {
         readonly Uri _remoteUri = new Uri(TestHelpers.GetTestRemoteModelRegistry());
-        readonly Uri _localUri = new Uri($@"file://{TestHelpers.GetTestLocalModelRegistry()}");
+        readonly Uri _localUri = new Uri($"file://{TestHelpers.GetTestLocalModelRegistry()}");
         IModelFetcher _localFetcher;
         IModelFetcher _remoteFetcher;
 
@@ -36,7 +36,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
         {
             string targetDtmi = "dtmi:com:example:thermostat;1";
 
-            Uri invalidFileUri = new Uri($@"file://totally/fake/path/please");
+            Uri invalidFileUri = new Uri("file://totally/fake/path/please");
             Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await _localFetcher.FetchAsync(targetDtmi, invalidFileUri));
         }
 

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ParserIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ParserIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
             };
 
             string TestRegistryPath = TestHelpers.GetTestLocalModelRegistry();
-            string testModelPath = $@"{TestRegistryPath}/dtmi/company/demodevice-1.json";
+            string testModelPath = $"{TestRegistryPath}/dtmi/company/demodevice-1.json";
 
             // Shows how to quickly integrate the resolver client with the parser.
             ResolverClient client = ResolverClient.FromLocalRegistry(TestRegistryPath);
@@ -38,7 +38,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
 
             // TODO: One off model -- need consistent remote model registry for IT's
             string TestRegistryPath = TestHelpers.GetTestLocalModelRegistry();
-            string testModelPath = $@"{TestRegistryPath}/dtmi/company/demodevice-2.json";
+            string testModelPath = $"{TestRegistryPath}/dtmi/company/demodevice-2.json";
 
             // Shows how to quickly integrate the resolver client with the parser.
             ResolverClient client = ResolverClient.FromRemoteRegistry(TestHelpers.GetTestRemoteModelRegistry());

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ResolveIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ResolveIntegrationTests.cs
@@ -43,7 +43,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
         public async Task ResolveSingleModelWithDeps(string dtmi, string expectedDeps)
         {
             var result = await localClient.ResolveAsync(dtmi);
-            var expectedDtmis = $@"{dtmi},{expectedDeps}".Split(',', System.StringSplitOptions.RemoveEmptyEntries);
+            var expectedDtmis = $"{dtmi},{expectedDeps}".Split(',', System.StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach(var id in expectedDtmis)
@@ -59,7 +59,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
         public async Task ResolveMultipleModelsWithDeps(string dtmi1, string dtmi2, string expectedDeps)
         {
             var result = await localClient.ResolveAsync(dtmi1, dtmi2); // Uses ResolveAsync(params string[])
-            var expectedDtmis = $@"{dtmi1},{dtmi2},{expectedDeps}".Split(',', System.StringSplitOptions.RemoveEmptyEntries);
+            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(',', System.StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach (var id in expectedDtmis)
@@ -86,7 +86,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
         public async Task ResolveMultipleModelsWithDepsVariant(string dtmi1, string dtmi2, string expectedDeps)
         {
             var result = await localClient.ResolveAsync(dtmi1, dtmi2);
-            var expectedDtmis = $@"{dtmi1},{dtmi2},{expectedDeps}".Split(',', System.StringSplitOptions.RemoveEmptyEntries);
+            var expectedDtmis = $"{dtmi1},{dtmi2},{expectedDeps}".Split(',', System.StringSplitOptions.RemoveEmptyEntries);
 
             Assert.True(result.Keys.Count == expectedDtmis.Length);
             foreach (var id in expectedDtmis)

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestHelpers.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestHelpers.cs
@@ -8,7 +8,7 @@ namespace Azure.DigitalTwins.Resolver.Tests
 {
     class TestHelpers
     {
-        readonly static string _fallbackTestRemoteRegistry = "https://iotmodels.github.io/registry/";
+        readonly static string _fallbackTestRemoteRegistry = "https://devicemodeltest.azureedge.net/";
 
         public static string ParseRootDtmiFromJson(string json)
         {

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/invalidmodel-2.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/invalidmodel-2.json
@@ -1,0 +1,23 @@
+﻿{
+  "@id": "dtmi:com:example:Phone;2",
+  "@type": "Interfacez",
+  "displayName": "Phone",
+  "contentsz": [
+    {
+      "@type": "Component",
+      "name": "frontCamera",
+      "schema": "dtmi:com:example:Camera;3"
+    },
+    {
+      "@type": "Component",
+      "name": "backCamera",
+      "schema": "dtmi:com:example:Camera;3"
+    },
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:azure:deviceManagement:DeviceInformation;2"
+    }
+  ],
+  "@context": "dtmi:dtdl:context;2"
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.sln
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.sln
@@ -16,6 +16,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.DigitalTwins.Resolver
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dtdl2-validator", "Tools\dtdl2-validator\dtdl2-validator.csproj", "{296A024B-5D0A-4283-AA64-B34032048D52}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.DigitalTwins.Resolver.CLI", "Azure.DigitalTwins.Resolver.CLI\Azure.DigitalTwins.Resolver.CLI.csproj", "{BF561D19-CAF1-47F4-93EE-9B9E88C013EC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{296A024B-5D0A-4283-AA64-B34032048D52}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{296A024B-5D0A-4283-AA64-B34032048D52}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{296A024B-5D0A-4283-AA64-B34032048D52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF561D19-CAF1-47F4-93EE-9B9E88C013EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF561D19-CAF1-47F4-93EE-9B9E88C013EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF561D19-CAF1-47F4-93EE-9B9E88C013EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF561D19-CAF1-47F4-93EE-9B9E88C013EC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/DtmiConventions.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/DtmiConventions.cs
@@ -18,7 +18,7 @@
                 basePath += "/";
             }
 
-            return $@"{basePath}{remoteModelPath}";
+            return $"{basePath}{remoteModelPath}";
         }
     }
 }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/LocalModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/LocalModelFetcher.cs
@@ -13,14 +13,14 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
 
             if (!Directory.Exists(registryPath))
             {
-                throw new DirectoryNotFoundException($@"Local registry directory '{registryPath}' not found or not accessible.");
+                throw new DirectoryNotFoundException($"Local registry directory '{registryPath}' not found or not accessible.");
             }
 
             string dtmiFilePath = DtmiConventions.ToPath(dtmi, registryPath);
 
             if (!File.Exists(dtmiFilePath))
             {
-                throw new FileNotFoundException($@"Model file '{dtmiFilePath}' not found or not accessible in local registry directory '{registryPath}'");
+                throw new FileNotFoundException($"Model file '{dtmiFilePath}' not found or not accessible in local registry directory '{registryPath}'");
             }
 
             return await File.ReadAllTextAsync(dtmiFilePath, Encoding.UTF8);

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverClient.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverClient.cs
@@ -15,7 +15,7 @@ namespace Azure.DigitalTwins.Resolver
 
         public static ResolverClient FromLocalRegistry(string registryPath)
         {
-            return new ResolverClient(new Uri($@"file://{registryPath}"));
+            return new ResolverClient(new Uri($"file://{registryPath}"));
         }
 
         public ResolverClient(Uri registryUri)

--- a/resolvers/dotnet/readme.md
+++ b/resolvers/dotnet/readme.md
@@ -1,7 +1,7 @@
 
 # Microsoft IoT Plug and Play Model Resolution Client
 
-## :exclamation: WARNING: This project is under heavy active development and should not be depended on in anyway until future notice
+## :exclamation: WARNING: This project is under heavy active development and should not be depended on until further notice
 
 ## Overview
 
@@ -91,10 +91,58 @@ Out of the box, the `ResolverClient` has a default configuration with common set
 
 - Coming soon!
 
-## Common Errors
+## Resolver Client CLI
 
-- Coming soon!
+This solution includes a CLI project `Azure.DigitalTwins.Resolver.CLI` to jumpstart scenarios. You are able to invoke commands via `dotnet run` or as the compiled executable `resolverclient`.
 
-## Contributing
+```bash
+resolverclient:
+  Microsoft IoT Plug and Play Model Resolution CLI
+
+Usage:
+  resolverclient [options] [command]
+
+Options:
+  --version         Show version information
+  -?, -h, --help    Show help and usage information
+
+Commands:
+  show        Retrieve a model and its dependencies by dtmi using the target registry for model resolution.
+  validate    Validates a model using the Digital Twins parser and target registry for model resolution.
+```
+
+**Examples**
+
+```bash
+# Retrieves the target model and its dependencies by dtmi using the default model registry.
+
+> resolverclient show --dtmi "dtmi:com:example:Thermostat;1"
+```
+
+```bash
+# Retrieves the target model and its dependencies by dtmi using a custom registry endpoint.
+
+> resolverclient show --dtmi "dtmi:com:example:Thermostat;1" --registry "https://mycustom.domain/models/"
+```
+
+```bash
+# Retrieves the target model and its dependencies by dtmi using a custom local registry.
+
+> resolverclient show --dtmi "dtmi:com:example:Thermostat;1" --registry "/my/models/"
+```
+
+```bash
+# Validates a DTDLv2 model using the Digital Twins Parser and default model registry for resolution.
+
+> resolverclient validate --model-file ./my/model/file.json
+```
+
+```bash
+# Validates a DTDLv2 model using the Digital Twins Parser and custom registry endpoint for resolution.
+
+> resolverclient validate --model-file ./my/model/file.json --registry "https://mycustom.domain/models/"
+```
+
+## Common Issues
 
 - Coming soon!


### PR DESCRIPTION
- This includes everything I demo'd, with the addition of showing the Parser version in logs for the `validate` command.
- Cleans up currently unneeded symbol for `ResolverClient`.