### PR TITLE
Error handling and traceability improvements checkpoint.

### DIFF
--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     <Copyright>Microsoft</Copyright>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
     <AssemblyName>resolverclient</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>resolverclient</ToolCommandName>

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Properties/launchSettings.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Properties/launchSettings.json
@@ -4,6 +4,14 @@
       "commandName": "Project",
       "commandLineArgs": "show --dtmi dtmi:com:example:Thermostat;1"
     },
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowBasicOutFile1": {
+      "commandName": "Project",
+      "commandLineArgs": "show --dtmi dtmi:com:example:Thermostat;1 -o mytestmodel.json"
+    },
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowBasicOutFile2": {
+      "commandName": "Project",
+      "commandLineArgs": "show --dtmi dtmi:com:example:TemperatureController;1 -o mytestmodel.json"
+    },
     "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowFail": {
       "commandName": "Project",
       "commandLineArgs": "show --dtmi dtmi:com:example:Thermojax;999"

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/Azure.DigitalTwins.Resolver.Tests.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/Azure.DigitalTwins.Resolver.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.4" />
+    <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ClientInitTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ClientInitTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+using Moq;
 using NUnit.Framework;
 using System;
 
@@ -5,6 +7,14 @@ namespace Azure.DigitalTwins.Resolver.Tests
 {
     public class ClientInitTests
     {
+        Mock<ILogger> _logger;
+
+        [SetUp]
+        public void Setup()
+        {
+            _logger = Mocks.GetGenericILogger();
+        }
+
         [Test]
         public void ClientInitGenericRegistryUri()
         {
@@ -24,16 +34,37 @@ namespace Azure.DigitalTwins.Resolver.Tests
         }
 
         [Test]
+        public void ClientInitGenericRegistryUriWithLogger()
+        {
+            string registryUriString = "https://localhost/myregistry/";
+            Uri registryUri = new Uri(registryUriString);
+            var client = new ResolverClient(registryUri, _logger.Object);
+            Assert.AreEqual(registryUri, client.RegistryUri);
+            _logger.Verify();
+        }
+
+        [Test]
+        public void ClientInitRemoteRegistryHelperWithLogger()
+        {
+            string registryUriString = "https://localhost/myregistry/";
+            Uri registryUri = new Uri(registryUriString);
+            var client = ResolverClient.FromRemoteRegistry(registryUriString, _logger.Object);
+            Assert.AreEqual(registryUri, client.RegistryUri);
+            _logger.Verify();
+        }
+
+        [Test]
         public void ClientInitLocalRegistryHelper()
         {
             string registryPathWindows = @"C:\Users\me\path\to\registy";
             string registryPathLinux = "/me/path/to/registry";
 
             Uri registryUriWindows = new Uri($"file://{registryPathWindows}");
-            var clientWindows = ResolverClient.FromLocalRegistry(registryPathWindows);
+            var clientWindows = ResolverClient.FromLocalRegistry(registryPathWindows, _logger.Object);
 
             Assert.AreEqual(registryUriWindows, clientWindows.RegistryUri);
             Assert.AreEqual(registryPathWindows.Replace('\\', '/'), clientWindows.RegistryUri.AbsolutePath);
+            _logger.Verify();
 
             Uri registryUriLinux = new Uri($"file://{registryPathLinux}");
             var clientLinux = ResolverClient.FromLocalRegistry(registryPathLinux);

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/Mocks.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/Mocks.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Azure.DigitalTwins.Resolver.Tests
+{
+    public class Mocks
+    {
+        public static Mock<ILogger> GetGenericILogger()
+        {
+            Mock<ILogger> logger = new Mock<ILogger>();
+            logger.Setup(x =>
+                x.Log(
+                    It.IsAny<LogLevel>(),
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>())
+                ).Verifiable();
+
+            return logger;
+        }
+    }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/coldstorage-1.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/coldstorage-1.json
@@ -1,0 +1,13 @@
+{
+  "@id": "dtmi:com:example:ColdStorage;1",
+  "@type": "Interface",
+  "extends": ["dtmi:com:example:Room;1", "dtmi:com:example:Freezer;1"],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "capacity",
+      "schema": "integer"
+    }
+  ],
+  "@context": "dtmi:dtdl:context;2"
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/freezer-1.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/freezer-1.json
@@ -1,0 +1,12 @@
+{
+  "@id": "dtmi:com:example:Freezer;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Component",
+      "name": "deviceInfo",
+      "schema": "dtmi:com:example:Thermostat;1"
+    }
+  ],
+  "@context": "dtmi:dtdl:context;2"
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Azure.DigitalTwins.Resolver.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Azure.DigitalTwins.Resolver.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.0.2</Version>
+    <Version>0.0.3</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -10,5 +10,9 @@
     <AssemblyName>Azure.DigitalTwins.Resolver</AssemblyName>
     <RootNamespace>Azure.DigitalTwins.Resolver</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
+  </ItemGroup>
 
 </Project>

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/ClientLogger.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/ClientLogger.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Azure.DigitalTwins.Resolver
+{
+    /// <summary>
+    /// Wrapper around ILogger to ensure safe logging across the client.
+    /// </summary>
+    public class ClientLogger
+    {
+        private readonly ILogger _logger;
+
+        public ClientLogger(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void LogInformation(string info, params object[] args)
+        {
+            if (_logger == null)
+                return;
+            _logger.LogInformation(info, args);
+        }
+
+        public void LogWarning(string info, params object[] args)
+        {
+            if (_logger == null)
+                return;
+            _logger.LogWarning(info, args);
+        }
+
+        public void LogError(string info, params object[] args)
+        {
+            if (_logger == null)
+                return;
+            _logger.LogError(info, args);
+        }
+    }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/IModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/IModelFetcher.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Threading.Tasks;
 
 namespace Azure.DigitalTwins.Resolver.Fetchers
 {
     public interface IModelFetcher
     {
-        Task<string> FetchAsync(string dtmi, Uri registryUri);
+        Task<string> FetchAsync(string dtmi, Uri registryUri, ClientLogger logger);
     }
 }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/LocalModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/LocalModelFetcher.cs
@@ -7,19 +7,24 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
 {
     public class LocalModelFetcher : IModelFetcher
     {
-        public async Task<string> FetchAsync(string dtmi, Uri registryUri)
+        public async Task<string> FetchAsync(string dtmi, Uri registryUri, ClientLogger logger)
         {
             string registryPath = registryUri.AbsolutePath;
 
             if (!Directory.Exists(registryPath))
             {
+                string dnfError = $"Local registry directory '{registryPath}' not found or not accessible.";
+                logger.LogError(dnfError);
                 throw new DirectoryNotFoundException($"Local registry directory '{registryPath}' not found or not accessible.");
             }
 
             string dtmiFilePath = DtmiConventions.ToPath(dtmi, registryPath);
+            logger.LogInformation($"Attempting to retrieve model content from {dtmiFilePath}");
 
             if (!File.Exists(dtmiFilePath))
             {
+                string fnfError = $"Model file '{dtmiFilePath}' not found or not accessible in local registry directory '{registryPath}'";
+                logger.LogError(fnfError);
                 throw new FileNotFoundException($"Model file '{dtmiFilePath}' not found or not accessible in local registry directory '{registryPath}'");
             }
 

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/RemoteModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/RemoteModelFetcher.cs
@@ -14,10 +14,12 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
             httpClient = new HttpClient();
         }
 
-        public async Task<string> FetchAsync(string dtmi, Uri registryUri)
+        public async Task<string> FetchAsync(string dtmi, Uri registryUri, ClientLogger logger)
         {
             string absoluteUri = registryUri.AbsoluteUri;
             string dtmiRemotePath = DtmiConventions.ToPath(dtmi, absoluteUri);
+
+            logger.LogInformation($"Attempting to retrieve model content from {dtmiRemotePath}");
 
             HttpResponseMessage response = await httpClient.GetAsync(dtmiRemotePath);
             response.EnsureSuccessStatusCode();

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverClient.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverClient.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -8,19 +9,19 @@ namespace Azure.DigitalTwins.Resolver
     {
         readonly RegistryHandler registryHandler = null;
 
-        public static ResolverClient FromRemoteRegistry(string registryUri)
+        public static ResolverClient FromRemoteRegistry(string registryUri, ILogger logger = null)
         {
-            return new ResolverClient(new Uri(registryUri));
+            return new ResolverClient(new Uri(registryUri), logger);
         }
 
-        public static ResolverClient FromLocalRegistry(string registryPath)
+        public static ResolverClient FromLocalRegistry(string registryPath, ILogger logger = null)
         {
-            return new ResolverClient(new Uri($"file://{registryPath}"));
+            return new ResolverClient(new Uri($"file://{registryPath}"), logger);
         }
 
-        public ResolverClient(Uri registryUri)
+        public ResolverClient(Uri registryUri, ILogger logger = null)
         {
-            this.registryHandler = new RegistryHandler(registryUri);
+            this.registryHandler = new RegistryHandler(registryUri, logger);
         }
 
         public async Task<IDictionary<string, string>> ResolveAsync(string dtmi)

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverException.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Azure.DigitalTwins.Resolver
+{
+    public class ResolverException : Exception
+    {
+        public ResolverException(string dtmi) : 
+            base($"Unable to resolve '{dtmi}'")
+        {
+        }
+
+        public ResolverException(string dtmi, string message) : 
+            base($"Unable to resolve '{dtmi}'. {message}")
+        {
+        }
+
+        public ResolverException(string dtmi, string message, Exception innerException) : 
+            base($"Unable to resolve '{dtmi}'. {message}", innerException)
+        {
+        }
+    }
+}


### PR DESCRIPTION
* ResolverClient supports optionally passing in an `ILogger`
* Uniform resolution exception `ResolverException` which aggregates inner
  exceptions (httpexception, filenotfound exception, directorynotfoundexception, etc).
* More clear error descriptions.
* Tests to support updates.
* CLI supports --output / -o for writing result content to file.
  This has the advantage over redirect to keep verbose logging on, while
  preserving only the model content to write to file.