### PR TITLE
Overhaul of model query and general ResolverClient improvements.

### DIFF
--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
@@ -7,14 +7,16 @@
     <Copyright>Microsoft</Copyright>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
-    <Version>0.0.5</Version>
-    <AssemblyName>resolverclient</AssemblyName>
+    <Version>0.0.6</Version>
+    <AssemblyName>dmrclient</AssemblyName>
     <PackAsTool>true</PackAsTool>
-    <ToolCommandName>resolverclient</ToolCommandName>
+    <ToolCommandName>dmrclient</ToolCommandName>
+    <PackageId>Azure.DigitalTwins.Resolver.CLI</PackageId>
+    <Product>Azure.DigitalTwins.Resolver.CLI</Product>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.4" />
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20371.2" />

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/CommonOptions.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/CommonOptions.cs
@@ -1,0 +1,41 @@
+﻿using System.CommandLine;
+
+namespace Azure.DigitalTwins.Resolver.CLI
+{
+    class CommonOptions
+    {
+        private const string _defaultRepository = "https://devicemodeltest.azureedge.net/";
+
+        public static Option<string> Dtmi()
+        {
+            return new Option<string>(
+                    "--dtmi",
+                    description: "Digital Twin Model Identifier. Example: dtmi:com:example:Thermostat;1")
+                    {
+                        Argument = new Argument<string>
+                        {
+                            Arity = ArgumentArity.ExactlyOne,
+                        },
+                        IsRequired = true
+                    };
+        }
+
+        public static Option<string> Repo()
+        {
+            return new Option<string>(
+                    "--repository",
+                    description: "Model Repository location. Can be remote endpoint or local directory.",
+                    getDefaultValue: () => _defaultRepository
+                    );
+        }
+
+        public static Option<string> Output()
+        {
+            return new Option<string>(
+                    new string[] { "--output", "-o" },
+                    description: "Desired file path to write result contents.",
+                    getDefaultValue: () => null
+                    );
+        }
+    }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Properties/launchSettings.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Properties/launchSettings.json
@@ -1,20 +1,28 @@
 {
   "profiles": {
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowBasic": {
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowRemote": {
       "commandName": "Project",
-      "commandLineArgs": "show --dtmi dtmi:com:example:Thermostat;1"
+      "commandLineArgs": "resolve --dtmi dtmi:com:example:Thermostat;1"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowBasicOutFile1": {
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowLocal": {
       "commandName": "Project",
-      "commandLineArgs": "show --dtmi dtmi:com:example:Thermostat;1 -o mytestmodel.json"
+      "commandLineArgs": "resolve --dtmi dtmi:com:example:Thermostat;1 --repository ../../../../Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowBasicOutFile2": {
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasic": {
       "commandName": "Project",
-      "commandLineArgs": "show --dtmi dtmi:com:example:TemperatureController;1 -o mytestmodel.json"
+      "commandLineArgs": "resolve --dtmi dtmi:com:example:Thermostat;1"
     },
-    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ShowFail": {
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasicOutFile1": {
       "commandName": "Project",
-      "commandLineArgs": "show --dtmi dtmi:com:example:Thermojax;999"
+      "commandLineArgs": "resolve --dtmi dtmi:com:example:Thermostat;1 -o mytestmodel.json"
+    },
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveBasicOutFile2": {
+      "commandName": "Project",
+      "commandLineArgs": "resolve --dtmi dtmi:com:example:TemperatureController;1 -o mytestmodel.json"
+    },
+    "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ResolveFail": {
+      "commandName": "Project",
+      "commandLineArgs": "resolve --dtmi dtmi:com:example:Thermojax;999"
     },
     "Azure.DigitalTwins.Resolver.CLI.SmokeTests.ValidateBasic": {
       "commandName": "Project",

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Extensions/Azure.DigitalTwins.Resolver.Extensions.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Extensions/Azure.DigitalTwins.Resolver.Extensions.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.4" />
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/Azure.DigitalTwins.Resolver.Tests.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/Azure.DigitalTwins.Resolver.Tests.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.4" />
+    <PackageReference Include="Microsoft.Azure.DigitalTwins.Parser" Version="3.12.5" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ClientTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ClientTests.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Azure.DigitalTwins.Resolver.Tests
 {
-    public class ClientInitTests
+    public class ClientTests
     {
         Mock<ILogger> _logger;
 
@@ -64,6 +64,16 @@ namespace Azure.DigitalTwins.Resolver.Tests
             Assert.AreEqual(registryPathLinux, clientLinux.RegistryUri.AbsolutePath);
 
             _logger.ValidateLog("Client initialized with file content fetcher.", LogLevel.Information, Times.Once());
+        }
+
+        [TestCase("dtmi:com:example:Thermostat;1", true)]
+        [TestCase("dtmi:contoso:scope:entity;2", true)]
+        [TestCase("dtmi:com:example:Thermostat:1", false)]
+        [TestCase("dtmi:com:example::Thermostat;1", false)]
+        [TestCase("com:example:Thermostat;1", false)]
+        public void ClientIsValidDtmi(string dtmi, bool expected)
+        {
+            Assert.AreEqual(ResolverClient.IsValidDtmi(dtmi), expected);
         }
     }
 }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/FetchIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/FetchIntegrationTests.cs
@@ -30,11 +30,14 @@ namespace Azure.DigitalTwins.Resolver.Tests
         {
             string targetDtmi = "dtmi:com:example:thermostat;1";
 
+            string expectedPath = DtmiConventions.ToPath(targetDtmi, _localUri.AbsolutePath);
+            string fetcherPath = _localFetcher.GetPath(targetDtmi, _localUri);
+            Assert.AreEqual(fetcherPath, expectedPath);
+
             // Resolution correctness is covered in ResolverIntegrationTests
             string content = await _localFetcher.FetchAsync(targetDtmi, _localUri, _logger.Object);
             Assert.IsNotNull(content);
-
-            string expectedPath = DtmiConventions.ToPath(targetDtmi, _localUri.AbsolutePath);
+ 
             _logger.ValidateLog($"Attempting to retrieve model content from {expectedPath}", LogLevel.Information, Times.Once());
         }
 
@@ -64,11 +67,14 @@ namespace Azure.DigitalTwins.Resolver.Tests
         {
             string targetDtmi = "dtmi:com:example:thermostat;1";
 
+            string expectedPath = DtmiConventions.ToPath(targetDtmi, _remoteUri.AbsoluteUri);
+            string fetcherPath = _remoteFetcher.GetPath(targetDtmi, _remoteUri);
+            Assert.AreEqual(fetcherPath, expectedPath);
+
             // Resolution correctness is covered in ResolverIntegrationTests
             string content = await _remoteFetcher.FetchAsync(targetDtmi, _remoteUri, _logger.Object);
             Assert.IsNotNull(content);
 
-            string expectedPath = DtmiConventions.ToPath(targetDtmi, _remoteUri.AbsoluteUri);
             _logger.ValidateLog($"Attempting to retrieve model content from {expectedPath}", LogLevel.Information, Times.Once());
         }
 

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ModelQueryTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ModelQueryTests.cs
@@ -1,0 +1,132 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Azure.DigitalTwins.Resolver.Tests
+{
+    public class ModelQueryTests
+    {
+        readonly string _modelTemplate = @"{{
+            {0}
+            ""@type"": ""Interface"",
+            ""displayName"": ""Phone"",
+            {1}
+            {2}
+            ""@context"": ""dtmi:dtdl:context;2""
+        }}";
+
+        [TestCase("\"@id\": \"dtmi:com:example:thermostat;1\",", "dtmi:com:example:thermostat;1")]
+        [TestCase("\"@id\": \"\",", "")]
+        [TestCase("", "")]
+        public void GetId(string formatId, string expectedId)
+        {
+            string modelContent = string.Format(_modelTemplate, formatId, "", "");
+            ModelQuery query = new ModelQuery(modelContent);
+            Assert.AreEqual(query.GetId(), expectedId);
+        }
+
+        [TestCase(
+            @"
+            ""contents"":
+            [{
+                ""@type"": ""Property"",
+                ""name"": ""capacity"",
+                ""schema"": ""integer""
+            },
+            {
+                ""@type"": ""Component"",
+                ""name"": ""frontCamera"",
+                ""schema"": ""dtmi:com:example:Camera;3""
+            },
+            {
+                ""@type"": ""Component"",
+                ""name"": ""backCamera"",
+                ""schema"": ""dtmi:com:example:Camera;3""
+            },
+            {
+                ""@type"": ""Component"",
+                ""name"": ""deviceInfo"",
+                ""schema"": ""dtmi:azure:DeviceManagement:DeviceInformation;1""
+            }],",
+            "dtmi:com:example:Camera;3,dtmi:com:example:Camera;3,dtmi:azure:DeviceManagement:DeviceInformation;1")]
+        [TestCase(
+            @"
+            ""contents"":
+            [{
+              ""@type"": ""Property"",
+              ""name"": ""capacity"",
+              ""schema"": ""integer""
+            }],", "")]
+        [TestCase(@"""contents"":[],", "")]
+        [TestCase("", "")]
+        public void GetComponentSchema(string contents, string expected)
+        {
+            string[] expectedDtmis = expected.Split(",", System.StringSplitOptions.RemoveEmptyEntries);
+            string modelContent = string.Format(_modelTemplate, "", "", contents);
+            ModelQuery query = new ModelQuery(modelContent);
+            IList<string> componentSchemas = query.GetComponentSchemas();
+            Assert.AreEqual(componentSchemas.Count, expectedDtmis.Length);
+
+            foreach(string schema in componentSchemas)
+            {
+                Assert.Contains(schema, expectedDtmis);
+            }
+        }
+
+        [TestCase(
+            "\"extends\": [\"dtmi:com:example:Camera;3\",\"dtmi:azure:DeviceManagement:DeviceInformation;1\"],",
+            "dtmi:com:example:Camera;3,dtmi:azure:DeviceManagement:DeviceInformation;1")]
+        [TestCase("\"extends\": [],", "")]
+        [TestCase("\"extends\": \"dtmi:com:example:Camera;3\",", "dtmi:com:example:Camera;3")]
+        [TestCase("", "")]
+        public void GetExtends(string extends, string expected)
+        {
+            string[] expectedDtmis = expected.Split(",", System.StringSplitOptions.RemoveEmptyEntries);
+            string modelContent = string.Format(_modelTemplate, "", extends, "");
+            ModelQuery query = new ModelQuery(modelContent);
+            IList<string> extendsDtmis = query.GetExtends();
+            Assert.AreEqual(extendsDtmis.Count, expectedDtmis.Length);
+
+            foreach (string dtmi in extendsDtmis)
+            {
+                Assert.Contains(dtmi, expectedDtmis);
+            }
+        }
+
+        [TestCase(
+            "\"@id\": \"dtmi:com:example:thermostat;1\",",
+            "\"extends\": [\"dtmi:com:example:Camera;3\",\"dtmi:azure:DeviceManagement:DeviceInformation;1\"],",
+            @"""contents"":
+            [{
+              ""@type"": ""Property"",
+              ""name"": ""capacity"",
+              ""schema"": ""integer""
+            },
+            {
+                ""@type"": ""Component"",
+                ""name"": ""frontCamera"",
+                ""schema"": ""dtmi:com:example:Camera;3""
+            },
+            {
+                ""@type"": ""Component"",
+                ""name"": ""backCamera"",
+                ""schema"": ""dtmi:com:example:Camera;3""
+            }],",
+            "dtmi:com:example:Camera;3,dtmi:azure:DeviceManagement:DeviceInformation;1"
+        )]
+        public void GetModelDependencies(string id, string extends, string contents, string expected)
+        {
+            string[] expectedDtmis = expected.Split(",", System.StringSplitOptions.RemoveEmptyEntries);
+            string modelContent = string.Format(_modelTemplate, id, extends, contents);
+            ModelQuery.ModelMetadata metadata = new ModelQuery(modelContent).GetMetadata();
+
+            IList<string> dependencies = metadata.Dependencies;
+
+            Assert.AreEqual(dependencies.Count, expectedDtmis.Length);
+
+            foreach (string dtmi in dependencies)
+            {
+                Assert.Contains(dtmi, expectedDtmis);
+            }
+        }
+    }
+}

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ParserIntegrationTests.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/ParserIntegrationTests.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using System;
 
 namespace Azure.DigitalTwins.Resolver.Tests
 {
@@ -12,20 +13,54 @@ namespace Azure.DigitalTwins.Resolver.Tests
         [Test]
         public async Task ParserValidationResolveFromLocalRegistry()
         {
-            ModelParser parser = new ModelParser
+            ModelParser parser = new ModelParser();
+            string TestRegistryPath = TestHelpers.GetTestLocalModelRegistry();
+
+            List<string> parseModelPaths = new List<string>()
             {
-                Options = new HashSet<ModelParsingOption>() { ModelParsingOption.StrictPartitionEnforcement }
+                $"{TestRegistryPath}/dtmi/company/demodevice-2.json",
+                $"{TestRegistryPath}/dtmi/com/example/temperaturecontroller-1.json",
+                $"{TestRegistryPath}/dtmi/com/example/camera-3.json",
             };
 
+            // Shows how to quickly integrate the resolver client with the parser.
+            ResolverClient client = ResolverClient.FromLocalRegistry(TestRegistryPath);
+            parser.DtmiResolver = client.ParserDtmiResolver;
+
+            foreach(string modelPath in parseModelPaths) {
+                // Parser will throw on validation errors
+                try {
+                    await parser.ParseAsync(new string[] { File.ReadAllText(modelPath) });
+                }
+                catch (Exception e)
+                {
+                    Assert.Fail(e.Message);
+                }
+            }
+        }
+
+        [Test]
+        public void ParserValidationResolveFromLocalRegistryErrorOnParserCallbackDtmiCasing()
+        {
+            ModelParser parser = new ModelParser();
             string TestRegistryPath = TestHelpers.GetTestLocalModelRegistry();
-            string testModelPath = $"{TestRegistryPath}/dtmi/company/demodevice-1.json";
+
+            // This model references another model with invalid casing.
+            string modelPath = $"{TestRegistryPath}/dtmi/company/demodevice-1.json";
 
             // Shows how to quickly integrate the resolver client with the parser.
             ResolverClient client = ResolverClient.FromLocalRegistry(TestRegistryPath);
             parser.DtmiResolver = client.ParserDtmiResolver;
 
             // Parser will throw on validation errors
-            await parser.ParseAsync(new string[] { File.ReadAllText(testModelPath) });
+
+            ResolverException e = 
+                Assert.ThrowsAsync<ResolverException>(async () => await parser.ParseAsync(new string[] { File.ReadAllText(modelPath) }));
+
+            Assert.AreEqual(e.Message,
+                "Unable to resolve 'dtmi:azure:deviceManagement:DeviceInformation;1'. " +
+                "Retrieved model content has incorrect DTMI casing. Expected dtmi:azure:deviceManagement:DeviceInformation;1, " +
+                "parsed dtmi:azure:DeviceManagement:DeviceInformation;1");
         }
 
         [Test]

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/azure/devicemanagement/deviceinformation-1.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/azure/devicemanagement/deviceinformation-1.json
@@ -1,6 +1,6 @@
 {
   "@context": "dtmi:dtdl:context;2",
-  "@id": "dtmi:azure:deviceManagement:DeviceInformation;1",
+  "@id": "dtmi:azure:DeviceManagement:DeviceInformation;1",
   "@type": "Interface",
   "displayName": "Device Information",
   "contents": [

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/azure/devicemanagement/deviceinformation-2.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/azure/devicemanagement/deviceinformation-2.json
@@ -1,8 +1,8 @@
 {
   "@context": "dtmi:dtdl:context;2",
-  "@id": "dtmi:azure:deviceManagement:DeviceInformation;2",
+  "@id": "dtmi:azure:DeviceManagement:DeviceInformation;2",
   "@type": "Interface",
-  "extends": "dtmi:azure:deviceManagement:DeviceInformation;1",
+  "extends": "dtmi:azure:DeviceManagement:DeviceInformation;1",
   "displayName": "Device Information",
   "contents": [
     {

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/camera-3.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/camera-3.json
@@ -6,7 +6,7 @@
     {
       "@type": "Component",
       "name": "deviceInfo",
-      "schema": "dtmi:azure:deviceManagement:DeviceInformation;1"
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1"
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/phone-2.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/phone-2.json
@@ -16,7 +16,7 @@
     {
       "@type": "Component",
       "name": "deviceInfo",
-      "schema": "dtmi:azure:deviceManagement:DeviceInformation;2"
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;2"
     }
   ],
   "@context": "dtmi:dtdl:context;2"

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/temperaturecontroller-1.json
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.Tests/TestModelRegistry/dtmi/com/example/temperaturecontroller-1.json
@@ -51,7 +51,7 @@
     },
     {
       "@type": "Component",
-      "schema": "dtmi:azure:deviceManagement:DeviceInformation;1",
+      "schema": "dtmi:azure:DeviceManagement:DeviceInformation;1",
       "name": "deviceInformation",
       "displayName": "Device Information interface",
       "description": "Optional interface with basic device hardware information."

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Azure.DigitalTwins.Resolver.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Azure.DigitalTwins.Resolver.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/IModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/IModelFetcher.cs
@@ -7,5 +7,7 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
     public interface IModelFetcher
     {
         Task<string> FetchAsync(string dtmi, Uri registryUri, ILogger logger);
+
+        string GetPath(string dtmi, Uri registryUri);
     }
 }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/LocalModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/LocalModelFetcher.cs
@@ -19,7 +19,7 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
                 throw new DirectoryNotFoundException($"Local registry directory '{registryPath}' not found or not accessible.");
             }
 
-            string dtmiFilePath = DtmiConventions.ToPath(dtmi, registryPath);
+            string dtmiFilePath = GetPath(dtmi, registryUri);
             logger.LogInformation($"Attempting to retrieve model content from {dtmiFilePath}");
 
             if (!File.Exists(dtmiFilePath))
@@ -30,6 +30,12 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
             }
 
             return await File.ReadAllTextAsync(dtmiFilePath, Encoding.UTF8);
+        }
+
+        public string GetPath(string dtmi, Uri registryUri)
+        {
+            string registryPath = registryUri.AbsolutePath;
+            return DtmiConventions.ToPath(dtmi, registryPath);
         }
     }
 }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/RemoteModelFetcher.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/Fetchers/RemoteModelFetcher.cs
@@ -17,15 +17,19 @@ namespace Azure.DigitalTwins.Resolver.Fetchers
 
         public async Task<string> FetchAsync(string dtmi, Uri registryUri, ILogger logger)
         {
-            string absoluteUri = registryUri.AbsoluteUri;
-            string dtmiRemotePath = DtmiConventions.ToPath(dtmi, absoluteUri);
-
+            string dtmiRemotePath = GetPath(dtmi, registryUri);
             logger.LogInformation($"Attempting to retrieve model content from {dtmiRemotePath}");
 
             HttpResponseMessage response = await httpClient.GetAsync(dtmiRemotePath);
             response.EnsureSuccessStatusCode();
 
             return await response.Content.ReadAsStringAsync();
+        }
+
+        public string GetPath(string dtmi, Uri registryUri)
+        {
+            string absoluteUri = registryUri.AbsoluteUri;
+            return DtmiConventions.ToPath(dtmi, absoluteUri);
         }
     }
 }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverClient.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverClient.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -37,6 +38,16 @@ namespace Azure.DigitalTwins.Resolver
         public async Task<IDictionary<string, string>> ResolveAsync(IEnumerable<string> dtmis)
         {
             return await this.registryHandler.ProcessAsync(dtmis, true);
+        }
+
+        public string GetPath(string dtmi)
+        {
+            return this.registryHandler.ToPath(dtmi);
+        }
+
+        public static bool IsValidDtmi(string dtmi)
+        {
+            return RegistryHandler.IsValidDtmi(dtmi);
         }
 
         public Uri RegistryUri { get { return this.registryHandler.RegistryUri; } }

--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverException.cs
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver/ResolverException.cs
@@ -5,7 +5,7 @@ namespace Azure.DigitalTwins.Resolver
     public class ResolverException : Exception
     {
         public ResolverException(string dtmi) : 
-            base($"Unable to resolve '{dtmi}'")
+            base($"Unable to resolve '{dtmi}'. ")
         {
         }
 

--- a/resolvers/dotnet/readme.md
+++ b/resolvers/dotnet/readme.md
@@ -59,11 +59,8 @@ using Azure.DigitalTwins.Resolver;
 using Azure.DigitalTwins.Resolver.Extensions;
 
 
-// Instantiate a parser as usual
-ModelParser parser = new ModelParser
-{
-    Options = new HashSet<ModelParsingOption>() { ModelParsingOption.StrictPartitionEnforcement }
-};
+// Instantiate the parser as usual
+ModelParser parser = new ModelParser()
 
 // Make a resolver client using the desired registry
 ResolverClient client = ResolverClient.FromRemoteRegistry("https://iotmodels.github.io/registry/");
@@ -127,7 +124,7 @@ catch (ResolverException resolverEx)
 
 ## Settings
 
-Out of the box, the `ResolverClient` has default settings with common options so it is not strictly necessary for to provide one.
+Out of the box, the `ResolverClient` has default settings with common options so it is not strictly necessary for you to provide one.
 
 ### General Settings
 
@@ -137,60 +134,79 @@ Out of the box, the `ResolverClient` has default settings with common options so
 
 - Coming soon!
 
-## Resolver Client CLI
+## Device Model Repository CLI
 
-This solution includes a CLI project `Azure.DigitalTwins.Resolver.CLI` to jumpstart scenarios. You are able to invoke commands via `dotnet run` or as the compiled executable `resolverclient`.
+This solution includes a CLI project `Azure.DigitalTwins.Resolver.CLI` to jumpstart scenarios. You are able to invoke commands via `dotnet run` or as the compiled executable `dmrclient`.
 
 ```bash
-resolverclient:
-  Microsoft IoT Plug and Play Model Resolution CLI
+dmrclient:
+  Microsoft IoT Plug and Play Device Model Repository CLI
 
 Usage:
-  resolverclient [options] [command]
+  dmrclient [options] [command]
 
 Options:
   --version         Show version information
   -?, -h, --help    Show help and usage information
 
 Commands:
-  show        Retrieve a model and its dependencies by dtmi using the target registry for model resolution.
-  validate    Validates a model using the Digital Twins parser and target registry for model resolution.
+  show        Shows the fully qualified path of an input dtmi. Does not evaluate existance of content.
+  resolve     Retrieve a model and its dependencies by dtmi using the target repository for model resolution.
+  validate    Validates a model using the Digital Twins model parser. Uses the target repository for model resolution.
 ```
 
-### Examples
+## Examples
+
+### dmrclient show
 
 ```bash
-# Retrieves the target model and its dependencies by dtmi using the default model registry.
+# Show the fully qualified path of dtmi:com:example:Thermostat;1 with respect to the default repository.
 
-> resolverclient show --dtmi "dtmi:com:example:Thermostat;1"
-```
-
-```bash
-# Retrieves the target model and its dependencies by dtmi using a custom registry endpoint.
-
-> resolverclient show --dtmi "dtmi:com:example:Thermostat;1" --registry "https://mycustom.domain/models/"
+> dmrclient show --dtmi "dtmi:com:example:Thermostat;1"
 ```
 
 ```bash
-# Retrieves the target model and its dependencies by dtmi using the default model registry and save contents to a new file with the path /my/model/result.json.
+# Show the fully qualified path of dtmi:com:example:Thermostat;1 with respect to a custom local repository.
 
-> resolverclient show --dtmi "dtmi:com:example:Thermostat;1" -o "/my/model/result.json"
+> dmrclient show --dtmi "dtmi:com:example:Thermostat;1" --repository "/my/model/repo"
+```
+
+### dmrclient resolve
+
+```bash
+# Retrieves the target model and its dependencies by dtmi using the default model repository.
+
+> dmrclient resolve --dtmi "dtmi:com:example:Thermostat;1"
 ```
 
 ```bash
-# Retrieves the target model and its dependencies by dtmi using a custom local registry.
+# Retrieves the target model and its dependencies by dtmi using a custom repository endpoint.
 
-> resolverclient show --dtmi "dtmi:com:example:Thermostat;1" --registry "/my/models/"
+> dmrclient resolve --dtmi "dtmi:com:example:Thermostat;1" --repository "https://mycustom.domain/models/"
 ```
 
 ```bash
-# Validates a DTDLv2 model using the Digital Twins Parser and default model registry for resolution.
+# Retrieves the target model and its dependencies by dtmi using the default model repository and save contents to a new file with the path /my/model/result.json.
 
-> resolverclient validate --model-file ./my/model/file.json
+> dmrclient resolve --dtmi "dtmi:com:example:Thermostat;1" -o "/my/model/result.json"
 ```
 
 ```bash
-# Validates a DTDLv2 model using the Digital Twins Parser and custom registry endpoint for resolution.
+# Retrieves the target model and its dependencies by dtmi using a custom local repository.
 
-> resolverclient validate --model-file ./my/model/file.json --registry "https://mycustom.domain/models/"
+> dmrclient resolve --dtmi "dtmi:com:example:Thermostat;1" --repository "/my/models/"
+```
+
+### dmrclient validate
+
+```bash
+# Validates a DTDLv2 model using the Digital Twins Parser and default model repository for resolution.
+
+> dmrclient validate --model-file ./my/model/file.json
+```
+
+```bash
+# Validates a DTDLv2 model using the Digital Twins Parser and custom repository endpoint for resolution.
+
+> dmrclient validate --model-file ./my/model/file.json --repository "https://mycustom.domain/models/"
 ```


### PR DESCRIPTION
- Renames `resolverclient` CLI to `dmrclient` and updates CLI descriptions/help.
- `show` command changed to show the fully qualified path to model content
- Added `resolve` command which does what the prior `show` did.
- `validate` command is unchanged.
- Updates all readme examples
- Overhaul/refactor of model query process to collect model KPI's.
- Added ability for client to validate DTMI format (and format is validated prior to processing)
- Added `GetPath` ResolverClient method (which is used in the CLI `show` command and internally by fetchers)
- Numerous test additions and improvements
- Updates Parser to `3.12.5`