### PR TITLE
Update package name

### DIFF
--- a/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
+++ b/resolvers/dotnet/Azure.DigitalTwins.Resolver.CLI/Azure.DigitalTwins.Resolver.CLI.csproj
@@ -8,10 +8,10 @@
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Version>0.0.6</Version>
-    <AssemblyName>dmrclient</AssemblyName>
+    <AssemblyName>dmr-client</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dmrclient</ToolCommandName>
-    <PackageId>Azure.DigitalTwins.Resolver.CLI</PackageId>
+    <PackageId>dmr-client</PackageId>
     <Product>Azure.DigitalTwins.Resolver.CLI</Product>
   </PropertyGroup>
 


### PR DESCRIPTION
use short name for CLI. Proposing `dmr-client` instead of `dmrclient` to be aligned with other dotnet tools

