### PR TITLE
Added --force option to import subcommand

### DIFF
--- a/.github/actions/validate-models/action.yml
+++ b/.github/actions/validate-models/action.yml
@@ -8,7 +8,7 @@ runs:
   steps:
     - name: 'Install Microsoft.IoT.ModelsRepository.CommandLine (dmr-client) from NuGet'
       run: |
-        dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.5
+        dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.8
       shell: bash
     - uses: 'actions/setup-python@v2'
       with:

--- a/.github/workflows/action-test-artifacts/validate-models/test_process.py
+++ b/.github/workflows/action-test-artifacts/validate-models/test_process.py
@@ -129,7 +129,7 @@ def test_handle_added_set(
     target_stderr = get_random_id()
     target_version = get_random_id()
     sample_debug = (
-        "ModelsRepositoryCommandLine/1.0.0-beta.5 "
+        "ModelsRepositoryCommandLine/1.0.0-beta.8 "
         "ModelsRepositoryClient/1.0.0-preview.4+b2e34443be8995bbb96d42ad32f5c3b290eed97e "
         f"DTDLParser/{target_version}\n"
     )

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/readme.md
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/readme.md
@@ -10,7 +10,7 @@ The Device Models Repository command line tool (aka `dmr-client`) is published o
 
 You can use the `dotnet` command line via the `dotnet tool install` command to install `dmr-client`. The following is an example to install `dmr-client` as a global tool:
 
-`dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.6`
+`dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.8`
 
 To learn how to install `dmr-client` in a local context, please see [this guide](https://docs.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use).
 
@@ -18,7 +18,7 @@ To learn how to install `dmr-client` in a local context, please see [this guide]
 
 ```text
 dmr-client
-  Microsoft IoT Models Repository CommandLine v1.0.0-beta.6
+  Microsoft IoT Models Repository CommandLine v1.0.0-beta.8
 
 Usage:
   dmr-client [options] [command]
@@ -30,7 +30,7 @@ Options:
   -?, -h, --help  Show help and usage information
 
 Commands:
-  export    Exports a model producing the model and its dependency chain in an expanded format. 
+  export    Exports a model producing the model and its dependency chain in an expanded format.
             The target repository is used for model resolution.
   validate  Validates the DTDL model contained in a file. When validating a single model object the target repository
             is used for model resolution. When validating an array of models only the array contents is used for resolution.

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/CommonOptions.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/CommonOptions.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.IoT.ModelsRepository;
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.IO;
+using Azure.IoT.ModelsRepository;
 
 namespace Microsoft.IoT.ModelsRepository.CommandLine
 {
@@ -127,7 +127,22 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
             }
         }
 
-        public static Option<bool> Silent
+
+      public static Option<bool> Force
+      {
+         get
+         {
+            return new Option<bool>(
+                alias: "--force",
+                description: "Forces import operation to override existing model file.",
+                getDefaultValue: () => false)
+            {
+               Arity = ArgumentArity.ZeroOrOne
+            };
+         }
+      }
+
+      public static Option<bool> Silent
         {
             get
             {

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Handlers.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Handlers.cs
@@ -79,7 +79,7 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
                     {
                         var enumeratedFile = new FileInfo(file);
                         result = await Validations.ValidateModelFileAsync(enumeratedFile, repoProvider, validationRules);
-                        
+
                         // TODO: Consider processing modes "return on first error", "return all errors"
                         if (result != ReturnCodes.Success)
                         {
@@ -132,7 +132,7 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
             return ReturnCodes.InvalidArguments;
         }
 
-        public static async Task<int> Import(FileInfo modelFile, DirectoryInfo directory, string searchPattern, DirectoryInfo localRepo)
+        public static async Task<int> Import(FileInfo modelFile, DirectoryInfo directory, string searchPattern, DirectoryInfo localRepo, bool force)
         {
             if (localRepo == null)
             {
@@ -150,7 +150,7 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
                         ensureContentRootType: false,
                         ensureDtmiNamespace: true);
 
-                    return await ModelImporter.ImportFileAsync(modelFile, localRepo, repoProvider, importFileValidationRules);
+                    return await ModelImporter.ImportFileAsync(modelFile, localRepo, repoProvider, force, importFileValidationRules);
                 }
 
                 // When importing models from an arbitrary directory we have to extract all models content
@@ -185,7 +185,7 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
                     int result;
                     foreach (KeyValuePair<FileInfo, List<string>> entry in contentMap)
                     {
-                        result = await ModelImporter.ImportFileAsync(entry.Key, localRepo, repoProvider, importDirectoryValidationRules);
+                        result = await ModelImporter.ImportFileAsync(entry.Key, localRepo, repoProvider, force, importDirectoryValidationRules);
                         if (result != ReturnCodes.Success)
                         {
                             return result;

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Microsoft.IoT.ModelsRepository.CommandLine.csproj
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Microsoft.IoT.ModelsRepository.CommandLine.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
-    <Version>1.0.0-beta.7</Version>
+    <Version>1.0.0-beta.8</Version>
     <AssemblyName>Microsoft.IoT.ModelsRepository.CommandLine</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dmr-client</ToolCommandName>
@@ -20,7 +20,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Description>Command line for the Azure IoT Models Repository</Description>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>https://github.com/Azure/iot-plugandplay-models-tools/blob/1.0.0-beta.7/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Azure/iot-plugandplay-models-tools/blob/1.0.0-beta.8/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/ModelImporter.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/ModelImporter.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.IoT.ModelsRepository;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Azure.IoT.ModelsRepository;
 
 namespace Microsoft.IoT.ModelsRepository.CommandLine
 {
     internal class ModelImporter
     {
-        public static void Import(string modelContent, DirectoryInfo repository)
+        public static void Import(string modelContent, DirectoryInfo repository, bool force)
         {
             string rootId = ParsingUtils.GetRootId(modelContent);
             string createPath = DtmiConventions.GetModelUri(rootId, new Uri(repository.FullName)).LocalPath;
@@ -19,17 +19,22 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
             Outputs.WriteOut($"* Importing model \"{rootId}\".");
             if (File.Exists(createPath))
             {
+                if (!force)
+                {
                 Outputs.WriteOut(
                     $"* Skipping \"{rootId}\". Model file already exists in repository.",
                     ConsoleColor.DarkCyan);
                 return;
+                }
+            Outputs.WriteOut(
+                $"* Overriding existing model \"{rootId}\" because --force option is set.");
             }
 
             (new FileInfo(createPath)).Directory.Create();
             Outputs.WriteToFile(createPath, modelContent);
         }
 
-        public static async Task<int> ImportFileAsync(FileInfo modelFile, DirectoryInfo repository, RepoProvider repoProvider, ValidationRules rules=null)
+        public static async Task<int> ImportFileAsync(FileInfo modelFile, DirectoryInfo repository, RepoProvider repoProvider, bool force, ValidationRules rules=null)
         {
             int validationResult = await Validations.ValidateModelFileAsync(modelFile, repoProvider, rules);
             if (validationResult != ReturnCodes.Success)
@@ -43,7 +48,7 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
 
             foreach (string content in models)
             {
-                Import(content, repository);
+                Import(content, repository, force);
             }
 
             return ReturnCodes.Success;

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/ModelImporter.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/ModelImporter.cs
@@ -21,13 +21,13 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
             {
                 if (!force)
                 {
-                Outputs.WriteOut(
-                    $"* Skipping \"{rootId}\". Model file already exists in repository.",
-                    ConsoleColor.DarkCyan);
-                return;
+                    Outputs.WriteOut(
+                        $"* Skipping \"{rootId}\". Model file already exists in repository.",
+                        ConsoleColor.DarkCyan);
+                    return;
                 }
-            Outputs.WriteOut(
-                $"* Overriding existing model \"{rootId}\" because --force option is set.");
+                Outputs.WriteOut(
+                    $"* Overriding existing model \"{rootId}\" because --force option is set.");
             }
 
             (new FileInfo(createPath)).Directory.Create();

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Program.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Program.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Core.Diagnostics;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
@@ -10,6 +9,7 @@ using System.Diagnostics.Tracing;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure.Core.Diagnostics;
 
 namespace Microsoft.IoT.ModelsRepository.CommandLine
 {
@@ -113,11 +113,12 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine
                 CommonOptions.ModelsDirectory,
                 CommonOptions.ModelsDirectorySearchPattern,
                 CommonOptions.LocalRepo,
+                CommonOptions.Force
             };
             importModelCommand.Description =
                 "Imports models from a model file into the local repository. The local repository is used for model resolution. " +
                 "Target model files for import will first be validated to ensure adherence to IoT Models Repository conventions.";
-            importModelCommand.Handler = CommandHandler.Create<FileInfo, DirectoryInfo, string, DirectoryInfo>(Handlers.Import);
+            importModelCommand.Handler = CommandHandler.Create<FileInfo, DirectoryInfo, string, DirectoryInfo, bool>(Handlers.Import);
 
             return importModelCommand;
         }

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandImportIntegrationTests.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandImportIntegrationTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using Azure.IoT.ModelsRepository;
+using NUnit.Framework;
 
 namespace Microsoft.IoT.ModelsRepository.CommandLine.Tests
 {
@@ -57,6 +57,16 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine.Tests
             modelFile = new FileInfo(Path.GetFullPath(testImportRepo.FullName + "/" + modelFilePath));
             Assert.AreEqual(lastWriteTimeUtc, modelFile.LastWriteTimeUtc);
             Assert.True(standardOut.Contains($"Skipping \"{expectedDtmi}\". Model file already exists in repository."));
+
+            (returnCode, standardOut, _) =
+                ClientInvokator.Invoke($"import --force --model-file \"{qualifiedModelFilePath}\" {targetRepo}");
+
+            Assert.AreEqual(ReturnCodes.Success, returnCode);
+            modelFile = new FileInfo(Path.GetFullPath(testImportRepo.FullName + "/" + modelFilePath));
+            Assert.True(modelFile.Exists);
+            lastWriteTimeUtc = modelFile.LastWriteTimeUtc;
+            Assert.AreEqual(expectedDtmi, ParsingUtils.GetRootId(modelFile));
+            Assert.True(standardOut.Contains($"Overriding existing model \"{expectedDtmi}\" because --force option is set."));
         }
 
         [TestCase(

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandImportIntegrationTests.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandImportIntegrationTests.cs
@@ -58,13 +58,14 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine.Tests
             Assert.AreEqual(lastWriteTimeUtc, modelFile.LastWriteTimeUtc);
             Assert.True(standardOut.Contains($"Skipping \"{expectedDtmi}\". Model file already exists in repository."));
 
+            // Import the same model with --force to ensure its overwritten.
             (returnCode, standardOut, _) =
                 ClientInvokator.Invoke($"import --force --model-file \"{qualifiedModelFilePath}\" {targetRepo}");
 
             Assert.AreEqual(ReturnCodes.Success, returnCode);
             modelFile = new FileInfo(Path.GetFullPath(testImportRepo.FullName + "/" + modelFilePath));
             Assert.True(modelFile.Exists);
-            lastWriteTimeUtc = modelFile.LastWriteTimeUtc;
+            Assert.Less(lastWriteTimeUtc, modelFile.LastWriteTimeUtc);
             Assert.AreEqual(expectedDtmi, ParsingUtils.GetRootId(modelFile));
             Assert.True(standardOut.Contains($"Overriding existing model \"{expectedDtmi}\" because --force option is set."));
         }


### PR DESCRIPTION
We need to import ever-changing models from partners and REC4 models repo - these models keep updating (usually adding stuff) while keeping the same versions/@ID. When importing them, we want to override the existing models in dtmi repo.

This PR adds 'import --force' option (disabled by default)