### PR TITLE
Update dmr client to GA DTDL parser

### DIFF
--- a/.github/actions/validate-models/action.yml
+++ b/.github/actions/validate-models/action.yml
@@ -8,7 +8,7 @@ runs:
   steps:
     - name: 'Install Microsoft.IoT.ModelsRepository.CommandLine (dmr-client) from NuGet'
       run: |
-        dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.8
+        dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.9
       shell: bash
     - uses: 'actions/setup-python@v2'
       with:

--- a/.github/workflows/action-test-artifacts/validate-models/test_process.py
+++ b/.github/workflows/action-test-artifacts/validate-models/test_process.py
@@ -129,7 +129,7 @@ def test_handle_added_set(
     target_stderr = get_random_id()
     target_version = get_random_id()
     sample_debug = (
-        "ModelsRepositoryCommandLine/1.0.0-beta.8 "
+        "ModelsRepositoryCommandLine/1.0.0-beta.9 "
         "ModelsRepositoryClient/1.0.0-preview.4+b2e34443be8995bbb96d42ad32f5c3b290eed97e "
         f"DTDLParser/{target_version}\n"
     )

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.8 (2023-03)
+## 1.0.0-beta.9 (2023-05)
 
 - Switch to latest DTDLParser (1.0.52). Please note: no version and major.minor version forms in DTMIs are not supported
 

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.0-beta.9 (2023-05)
 
-- Switch to latest DTDLParser (1.0.52). Please note: no version and major.minor version forms in DTMIs are not supported
+- Switch to latest DTDLParser (1.0.52). Please note: no version and major.minor version forms in DTMIs are not supported for DTDL v3 models
 
 ## 1.0.0-beta.8 (2023-03)
 

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.0.0-beta.8 (2023-03)
 
+- Switch to latest DTDLParser (1.0.52). Please note: no version and major.minor version forms in DTMIs are not supported
+
+## 1.0.0-beta.8 (2023-03)
+
 - Update target frameworks to net6 and net7
 - Removes net31 and net5 support
 - Support DTDL v3 (behind the argument `max-dtdl-version`)

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/readme.md
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/readme.md
@@ -10,7 +10,7 @@ The Device Models Repository command line tool (aka `dmr-client`) is published o
 
 You can use the `dotnet` command line via the `dotnet tool install` command to install `dmr-client`. The following is an example to install `dmr-client` as a global tool:
 
-`dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.8`
+`dotnet tool install -g Microsoft.IoT.ModelsRepository.CommandLine --version 1.0.0-beta.9`
 
 To learn how to install `dmr-client` in a local context, please see [this guide](https://docs.microsoft.com/en-us/dotnet/core/tools/local-tools-how-to-use).
 
@@ -18,7 +18,7 @@ To learn how to install `dmr-client` in a local context, please see [this guide]
 
 ```text
 dmr-client
-  Microsoft IoT Models Repository CommandLine v1.0.0-beta.8
+  Microsoft IoT Models Repository CommandLine v1.0.0-beta.9
 
 Usage:
   dmr-client [options] [command]

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Microsoft.IoT.ModelsRepository.CommandLine.csproj
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Microsoft.IoT.ModelsRepository.CommandLine.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
-    <Version>1.0.0-beta.8</Version>
+    <Version>1.0.0-beta.9</Version>
     <AssemblyName>Microsoft.IoT.ModelsRepository.CommandLine</AssemblyName>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dmr-client</ToolCommandName>
@@ -20,7 +20,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Description>Command line for the Azure IoT Models Repository</Description>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>https://github.com/Azure/iot-plugandplay-models-tools/blob/1.0.0-beta.8/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Azure/iot-plugandplay-models-tools/blob/1.0.0-beta.9/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/CHANGELOG.md</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Microsoft.IoT.ModelsRepository.CommandLine.csproj
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Microsoft.IoT.ModelsRepository.CommandLine.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Iot.ModelsRepository" Version="1.0.0-preview.5" />
-    <PackageReference Include="DTDLParser" Version="1.0.37-preview-g0f8f3131c8" />
+    <PackageReference Include="DTDLParser" Version="1.0.52" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Properties/launchSettings.json
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/src/Properties/launchSettings.json
@@ -87,6 +87,14 @@
     "Microsoft.IoT.ModelsRepository.CommandLine.ImportVersion4": {
       "commandName": "Project",
       "commandLineArgs": "import --model-file ../../../../tests/TestModelRepo/dtmi/version3/emptyv3-1.json --max-dtdl-version 4"
+    },
+    "Microsoft.IoT.ModelsRepository.CommandLine.ValidateContentVersion3": {
+      "commandName": "Project",
+      "commandLineArgs": "validate --model-file ../../../../tests/TestModelRepo/dtmi/version3/newv3-1.json --max-dtdl-version 3"
+    },
+    "Microsoft.IoT.ModelsRepository.CommandLine.ImportContentVersion3": {
+      "commandName": "Project",
+      "commandLineArgs": "import --model-file ../../../../tests/TestModelRepo/dtmi/version3/newv3-1.json --max-dtdl-version 3"
     }
   }
 }

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandImportIntegrationTests.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandImportIntegrationTests.cs
@@ -284,5 +284,20 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine.Tests
             Assert.IsEmpty(standardError);
             Assert.True(standardOut.Contains("* Validating model file content conforms to DTDL version 3."));
         }
+
+        [TestCase("dtmi/version3/newv3-1.json", ReturnCodes.Success)]
+        public void ImportNewUpdatesInV3(string modelFilePath, int expectedReturnCode)
+        {
+            string qualifiedModelFilePath = Path.Combine(TestHelpers.TestLocalModelRepository, modelFilePath);
+            string targetRepo = $"--local-repo \"{testImportRepo.FullName}\"";
+
+            (int returnCode, string standardOut, string standardError) =
+                ClientInvokator.Invoke($"import --model-file \"{qualifiedModelFilePath}\" {targetRepo} --max-dtdl-version 3");
+
+            Assert.AreEqual(expectedReturnCode, returnCode);
+
+            Assert.IsEmpty(standardError);
+            Assert.True(standardOut.Contains("* Validating model file content conforms to DTDL version 3."));
+        }
     }
 }

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandValidateIntegrationTests.cs
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/CommandValidateIntegrationTests.cs
@@ -390,5 +390,18 @@ namespace Microsoft.IoT.ModelsRepository.CommandLine.Tests
             Assert.AreEqual(expectedReturnCode, returnCode);
             Assert.True(standardOut.Contains("* Validating model file content conforms to DTDL version 3."));
         }
+
+        [TestCase("dtmi/version3/newv3-1.json", ReturnCodes.Success)]
+        public void ValidateNewUpdatesInV3(string modelFilePath, int expectedReturnCode)
+        {
+            string qualifiedModelFilePath = Path.Combine(TestHelpers.TestLocalModelRepository, modelFilePath);
+            (int returnCode, string standardOut, string standardError) =
+                ClientInvokator.Invoke($"" +
+                $"validate --model-file \"{qualifiedModelFilePath}\" " +
+                $"--max-dtdl-version 3 " +
+                $"--repo \"{TestHelpers.TestLocalModelRepository}\" ");
+            Assert.AreEqual(expectedReturnCode, returnCode);
+            Assert.True(standardOut.Contains("* Validating model file content conforms to DTDL version 3."));
+        }
     }
 }

--- a/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/TestModelRepo/dtmi/version3/newv3-1.json
+++ b/clients/dotnet/Microsoft.IoT.ModelsRepository.CommandLine/tests/TestModelRepo/dtmi/version3/newv3-1.json
@@ -1,0 +1,62 @@
+{
+  "@context": "dtmi:dtdl:context;3",
+  "@id": "dtmi:version3:newv3;1",
+  "@type": "Interface",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temperature",
+      "schema": "double"
+    },
+    {
+      "@type": "Property",
+      "name": "setPointTemp",
+      "schema": "point",
+      "writable": true
+    },
+    {
+      "@type": "Telemetry",
+      "name": "state",
+      "schema": {
+        "@type": "Enum",
+        "valueSchema": "integer",
+        "enumValues": []
+      }
+    },
+    {
+      "@type": "Telemetry",
+      "name": "accelerometer",
+      "schema": {
+        "@type": "Object",
+        "fields": []
+      }
+    },
+    {
+      "@type": "Command",
+      "commandType": "synchronous",
+      "description": {
+        "en": "Reboots the device after waiting the number of seconds specified."
+      },
+      "displayName": {
+        "en": "Reboot"
+      },
+      "name": "reboot",
+      "request": {
+        "@type": "CommandRequest",
+        "displayName": {
+          "en": "Restart Delay in seconds [3..9]"
+        },
+        "name": "RestartDelay",
+        "schema": "integer"
+      },
+      "response": {
+        "@type": "CommandResponse",
+        "displayName": {
+          "en": "Restart Device Result"
+        },
+        "name": "RestartDeviceResult",
+        "schema": "string"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Update dmr client to GA DTDL parser 1.0.52
And added a new test case according to [Changes from Version 2 guildline](https://github.com/Azure/opendigitaltwins-dtdl/blob/master/DTDL/v3/DTDL.v3.md#changes-from-version-2)