### PR TITLE
Bump .NET SDK to v7

### DIFF
--- a/.azure-devops/analysis.yml
+++ b/.azure-devops/analysis.yml
@@ -30,10 +30,10 @@ stages:
           vmImage: 'windows-2019'
         steps:
           - task: UseDotNet@2
-            displayName: 'Install net 6 sdk'
+            displayName: 'Install net 7 sdk'
             inputs:
               packageType: 'sdk'
-              version: '6.0.x'
+              version: '7.0.x'
           - task: Semmle@1
             inputs:
               sourceCodeDirectory: '$(targetProjectPath)/src'


### PR DESCRIPTION
Will fix a tooling error in our static analysis pipeline: 
https://dev.azure.com/azureiotdevxp/iot-modelsrepository/_build/results?buildId=8667&view=logs&j=5c559df6-519b-53be-82b1-d0713d75d40a&t=70a580b6-796f-54c7-7484-0fe43d4e7276&l=197